### PR TITLE
Align React Native dependencies with lockfile

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,10 +23,10 @@
     "@react-navigation/native-stack": "^6.9.17",
     "expo": "~51.0.6",
     "react": "18.2.0",
-    "react-native": "0.74.1",
+    "react-native": "0.74.5",
     "expo-clipboard": "~6.0.0",
     "react-native-gesture-handler": "~2.16.2",
-    "react-native-safe-area-context": "4.8.2",
+    "react-native-safe-area-context": "4.10.5",
     "react-native-screens": "~3.29.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- update package.json so the react-native and react-native-safe-area-context versions match the lockfile

## Testing
- npm install *(fails: 403 Forbidden retrieving @react-navigation/native)*

------
https://chatgpt.com/codex/tasks/task_e_68dc8560d15c8331824949b285708105